### PR TITLE
Use appropriate built-in PHP exceptions

### DIFF
--- a/src/EIKValidator/Exceptions/InvalidArgument.php
+++ b/src/EIKValidator/Exceptions/InvalidArgument.php
@@ -2,6 +2,6 @@
 
 namespace Mirovit\EIKValidator\Exceptions;
 
-class InvalidArgument extends \Exception
+class InvalidArgument extends \InvalidArgumentException
 {
 }

--- a/src/EIKValidator/Exceptions/InvalidLength.php
+++ b/src/EIKValidator/Exceptions/InvalidLength.php
@@ -2,6 +2,6 @@
 
 namespace Mirovit\EIKValidator\Exceptions;
 
-class InvalidLength extends \Exception
+class InvalidLength extends \OutOfRangeException
 {
 }


### PR DESCRIPTION
This keeps the exceptions interface in backwards-compatible manner,
but also extends the appropriate PHP exception.
